### PR TITLE
Cadastrar estabelecimento

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
-/.idea
+.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,12 @@
 AllCops:
   TargetRubyVersion: 2.6
 
+Metrics/BlockLength:
+  IgnoredMethods: ['describe', 'context', 'it']
+
+Style/Documentation:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     unicode-display_width (2.0.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/data/companies.csv
+++ b/data/companies.csv
@@ -1,0 +1,1 @@
+id,name,phone

--- a/data/companies.csv
+++ b/data/companies.csv
@@ -1,13 +1,1 @@
 id,name,phone
-1,toka do açai,""
-1,açaiasd asd,asdasd
-1,toka do açai,""
-1,açaiasd asd,asdasd
-1,toka do açai,""
-1,açaiasd asd,asdasd
-1,toka do açai,""
-1,açaiasd asd,asdasd
-1,toka do açai,""
-1,açaiasd asd,1234
-1,açaiasd asd,12345
-1,açaiasd asd,123456

--- a/data/companies.csv
+++ b/data/companies.csv
@@ -1,1 +1,13 @@
 id,name,phone
+1,toka do açai,""
+1,açaiasd asd,asdasd
+1,toka do açai,""
+1,açaiasd asd,asdasd
+1,toka do açai,""
+1,açaiasd asd,asdasd
+1,toka do açai,""
+1,açaiasd asd,asdasd
+1,toka do açai,""
+1,açaiasd asd,1234
+1,açaiasd asd,12345
+1,açaiasd asd,123456

--- a/lib/tem_acai.rb
+++ b/lib/tem_acai.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "tem_acai/version"
+require_relative "tem_acai/company"
 
 module TemAcai
   class Error < StandardError; end

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -2,6 +2,7 @@
 
 require "csv"
 class Company
+  ID_RANDOM_SET = 2000
   DATA_PATH = "data/companies.csv"
 
   attr_reader :id, :name, :phone
@@ -22,7 +23,9 @@ class Company
   end
 
   def self.create(name:, phone: "")
-    new_company = Company.new(id: 1, name: name, phone: phone)
+    id = rand(ID_RANDOM_SET)
+
+    new_company = Company.new(id: id, name: name, phone: phone)
 
     CSV.open(DATA_PATH, "ab") do |csv|
       csv << [new_company.id, new_company.name, new_company.phone]

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -4,20 +4,28 @@ require "csv"
 class Company
   DATA_PATH = "data/companies.csv"
 
+  attr_reader :id, :name, :phone
+
+  def initialize(id:, name:, phone: "")
+    @id = id
+    @name = name
+    @phone = phone
+  end
+
   def self.all
     companies = []
 
     CSV.read(DATA_PATH, headers: true).each do |row|
-      companies << { id: row["id"], name: row["name"], phone: row["phone"] }
+      companies << Company.new(id: row["id"], name: row["name"], phone: row["phone"])
     end
     companies
   end
 
   def self.create(name:, phone: "")
-    new_company = { id: 1, name: name, phone: phone }
+    new_company = Company.new(id: 1, name: name, phone: phone)
 
     CSV.open(DATA_PATH, "ab") do |csv|
-      csv << [new_company[:id], new_company[:name], new_company[:phone]]
+      csv << [new_company.id, new_company.name, new_company.phone]
     end
 
     new_company

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -16,11 +16,9 @@ class Company
   def self.create(name:, phone: "")
     new_company = { id: 1, name: name, phone: phone }
 
-    companies_csv = CSV.open(DATA_PATH, "ab")
-
-    companies_csv << %w[id name phone] if File.empty?(companies_csv)
-
-    companies_csv << [new_company[:id], new_company[:name], new_company[:phone]]
+    CSV.open(DATA_PATH, "ab") do |csv|
+      csv << [new_company[:id], new_company[:name], new_company[:phone]]
+    end
 
     new_company
   end

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -1,5 +1,27 @@
+# frozen_string_literal: true
+
+require "csv"
 class Company
+  DATA_PATH = "data/companies.csv"
+
+  def self.all
+    companies = []
+
+    CSV.read(DATA_PATH, headers: true).each do |row|
+      companies << { id: row["id"], name: row["name"], phone: row["phone"] }
+    end
+    companies
+  end
+
   def self.create(name:, phone: "")
-    { id: 1, name: name, phone: phone }
+    new_company = { id: 1, name: name, phone: phone }
+
+    companies_csv = CSV.open(DATA_PATH, "ab")
+
+    companies_csv << %w[id name phone] if File.empty?(companies_csv)
+
+    companies_csv << [new_company[:id], new_company[:name], new_company[:phone]]
+
+    new_company
   end
 end

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -1,0 +1,5 @@
+class Company
+  def self.create(name:, phone: "")
+    { id: 1, name: name, phone: phone }
+  end
+end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -26,13 +26,25 @@ RSpec.describe Company do
       expect(company.phone).to eq("")
     end
 
-    it "persists the data" do
+    it "creates a company" do
       companies = Company.all
-      Company.create(name: "Casa do Açaí")
+      Company.create(name: "Casa do Açaí", phone: "11-11111111")
       new_companies = Company.all
 
       expect(companies).to be_empty
       expect(new_companies.first.name).to eq("Casa do Açaí")
+      expect(new_companies.first.phone).to eq("11-11111111")
+      expect(new_companies.first.id).to be_truthy
+    end
+
+    it "creates four companies" do
+      Company.create(name: "Casa do Açaí")
+      Company.create(name: "Toca do Açaí")
+      Company.create(name: "Açaí da Esquina")
+      Company.create(name: "Tudo Açaí")
+      companies = Company.all
+
+      expect(companies.length).to eq(4)
     end
   end
 

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -2,15 +2,14 @@
 
 RSpec.describe Company do
   context ".create" do
-    before do
-      test_data_path = "spec/support/companies-test.csv"
-      stub_const("Company::DATA_PATH", test_data_path)
+    csv_path = "spec/support/companies-test.csv"
 
-      CSV.open(test_data_path, "wb") do |csv|
-        csv << %w[id name phone]
-        csv.close
-      end
+    before do
+      stub_const("Company::DATA_PATH", csv_path)
+      restart_csv(csv_path)
     end
+
+    after(:all) { restart_csv(csv_path) }
 
     it "creates a company with id, name and phone" do
       company = Company.create(name: "Casa do Açaí", phone: "11-11111111")
@@ -32,6 +31,12 @@ RSpec.describe Company do
       new_companies = Company.all
 
       expect(new_companies.to_s).to include("Casa do Açaí")
+    end
+  end
+
+  def restart_csv(file_path)
+    CSV.open(file_path, "wb") do |csv|
+      csv << %w[id name phone]
     end
   end
 end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -1,5 +1,17 @@
+# frozen_string_literal: true
+
 RSpec.describe Company do
   context ".create" do
+    before do
+      test_data_path = "spec/support/companies-test.csv"
+      stub_const("Company::DATA_PATH", test_data_path)
+
+      CSV.open(test_data_path, "wb") do |csv|
+        csv << %w[id name phone]
+        csv.close
+      end
+    end
+
     it "creates a company with id, name and phone" do
       company = Company.create(name: "Casa do Açaí", phone: "11-11111111")
 
@@ -16,12 +28,9 @@ RSpec.describe Company do
     end
 
     it "persists the data" do
-      companies = Company.all
-      company = Company.create(name: "Casa do Açaí")
+      Company.create(name: "Casa do Açaí")
       new_companies = Company.all
 
-      expect(companies).to be_empty
-      expect(new_companies.size).to eq 1
       expect(new_companies.to_s).to include("Casa do Açaí")
     end
   end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Company do
+  context ".create" do
+    it "creates a company with id, name and phone" do
+      company = Company.create(name: "Casa do Açaí", phone: "11-11111111")
+
+      expect(company[:name]).to eq("Casa do Açaí")
+      expect(company[:phone]).to eq("11-11111111")
+      expect(company[:id]).to be_truthy
+    end
+  end
+end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -7,5 +7,22 @@ RSpec.describe Company do
       expect(company[:phone]).to eq("11-11111111")
       expect(company[:id]).to be_truthy
     end
+
+    it "without a phone" do
+      company = Company.create(name: "Casa do Açaí")
+
+      expect(company[:name]).to eq("Casa do Açaí")
+      expect(company[:phone]).to eq("")
+    end
+
+    it "persists the data" do
+      companies = Company.all
+      company = Company.create(name: "Casa do Açaí")
+      new_companies = Company.all
+
+      expect(companies).to be_empty
+      expect(new_companies.size).to eq 1
+      expect(new_companies.to_s).to include("Casa do Açaí")
+    end
   end
 end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -14,23 +14,25 @@ RSpec.describe Company do
     it "creates a company with id, name and phone" do
       company = Company.create(name: "Casa do Açaí", phone: "11-11111111")
 
-      expect(company[:name]).to eq("Casa do Açaí")
-      expect(company[:phone]).to eq("11-11111111")
-      expect(company[:id]).to be_truthy
+      expect(company.name).to eq("Casa do Açaí")
+      expect(company.phone).to eq("11-11111111")
+      expect(company.id).to be_truthy
     end
 
     it "without a phone" do
       company = Company.create(name: "Casa do Açaí")
 
-      expect(company[:name]).to eq("Casa do Açaí")
-      expect(company[:phone]).to eq("")
+      expect(company.name).to eq("Casa do Açaí")
+      expect(company.phone).to eq("")
     end
 
     it "persists the data" do
+      companies = Company.all
       Company.create(name: "Casa do Açaí")
       new_companies = Company.all
 
-      expect(new_companies.to_s).to include("Casa do Açaí")
+      expect(companies).to be_empty
+      expect(new_companies.first.name).to eq("Casa do Açaí")
     end
   end
 

--- a/spec/support/companies-test.csv
+++ b/spec/support/companies-test.csv
@@ -1,0 +1,1 @@
+id,name,phone


### PR DESCRIPTION
Adiciona funcionalidade de cadastrar um estabelecimento (company) e persisti-lo em um arquivo CSV.

Dados de um estabelecimento (Company):
- id (número gerado aleatóriamente)
- name (nome do estabelecimento)
- phone (telefone - opcional)

Closes #9 