### PR TITLE
Cadastrar endereço do estabelecimento

### DIFF
--- a/data/companies-addresses.csv
+++ b/data/companies-addresses.csv
@@ -1,1 +1,3 @@
 id,company_id,zip,street,city,state
+614,1623,11111-111,"Rua do Açaí, 25",São Paulo,SP
+1498,626,11111-111,"Rua do Açaí, 25",São Paulo,SP

--- a/data/companies-addresses.csv
+++ b/data/companies-addresses.csv
@@ -1,0 +1,1 @@
+id,company_id,zip,street,city,state

--- a/lib/tem_acai.rb
+++ b/lib/tem_acai.rb
@@ -2,6 +2,7 @@
 
 require_relative "tem_acai/version"
 require_relative "tem_acai/company"
+require_relative "tem_acai/company_address"
 require_relative "tem_acai/customer"
 
 module TemAcai

--- a/lib/tem_acai/company.rb
+++ b/lib/tem_acai/company.rb
@@ -42,6 +42,10 @@ class Company
     update_csv
   end
 
+  def address
+    CompanyAddress.from_company(id.to_s)
+  end
+
   private
 
   attr_writer :is_open

--- a/lib/tem_acai/company_address.rb
+++ b/lib/tem_acai/company_address.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "csv"
+class CompanyAddress
+  ID_RANDOM_SET = 2000
+  DATA_PATH = "data/companies-addresses.csv"
+
+  attr_reader :id, :company_id, :zip, :street, :city, :state
+
+  def initialize(id:, company_id:, zip:, street:, city:, state:) # rubocop:disable Metrics/ParameterLists
+    @id = id
+    @company_id = company_id
+    @zip = zip
+    @street = street
+    @city = city
+    @state = state
+  end
+
+  def self.create(company_id:, zip:, street:, city:, state:)
+    id = rand(ID_RANDOM_SET)
+
+    new_address = CompanyAddress.new(id: id, company_id: company_id, zip: zip, street: street, city: city,
+                                     state: state)
+
+    CSV.open(DATA_PATH, "ab") do |csv|
+      csv << [new_address.id, new_address.company_id, new_address.zip, new_address.street, new_address.city,
+              new_address.state]
+    end
+
+    new_address
+  end
+end

--- a/lib/tem_acai/company_address.rb
+++ b/lib/tem_acai/company_address.rb
@@ -16,6 +16,16 @@ class CompanyAddress
     @state = state
   end
 
+  def self.all
+    addresses = []
+
+    CSV.read(DATA_PATH, headers: true).each do |row|
+      addresses << CompanyAddress.new(id: row["id"], company_id: row["company_id"], zip: row["zip"],
+                                      street: row["street"], city: row["city"], state: row["state"])
+    end
+    addresses
+  end
+
   def self.create(company_id:, zip:, street:, city:, state:)
     id = rand(ID_RANDOM_SET)
 
@@ -28,5 +38,9 @@ class CompanyAddress
     end
 
     new_address
+  end
+
+  def self.from_company(company_id)
+    CompanyAddress.all.find { |address| address.company_id == company_id }
   end
 end

--- a/spec/company_address_spec.rb
+++ b/spec/company_address_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe CompanyAddress do
 
   context ".create" do
     it "creates a company address with id, company_id, zip, street, city, state" do
-      company_address = CompanyAddress.create(company_id: 123, zip: "11111-111", street: "Rua do Açaí, 25",
+      company_address = CompanyAddress.create(company_id: "123", zip: "11111-111", street: "Rua do Açaí, 25",
                                               city: "São Paulo", state: "SP")
 
-      expect(company_address.company_id).to eq(123)
+      expect(company_address.company_id).to eq("123")
       expect(company_address.street).to eq("Rua do Açaí, 25")
       expect(company_address.zip).to eq("11111-111")
       expect(company_address.city).to eq("São Paulo")
@@ -25,9 +25,10 @@ RSpec.describe CompanyAddress do
 
   context ".from_company" do
     it "returns the address from a company id" do
-      CompanyAddress.create(company_id: 123, zip: "11111-111", street: "Rua do Açaí, 25", city: "São Paulo", state: "SP")
+      CompanyAddress.create(company_id: "123", zip: "11111-111", street: "Rua do Açaí, 25", city: "São Paulo",
+                            state: "SP")
 
-      address = CompanyAddress.from_company(123)
+      address = CompanyAddress.from_company("123")
 
       expect(address.street).to eq("Rua do Açaí, 25")
       expect(address.zip).to eq("11111-111")

--- a/spec/company_address_spec.rb
+++ b/spec/company_address_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe CompanyAddress do
     end
   end
 
+  context ".from_company" do
+    it "returns the address from a company id" do
+      CompanyAddress.create(company_id: 123, zip: "11111-111", street: "Rua do Açaí, 25", city: "São Paulo", state: "SP")
+
+      address = CompanyAddress.from_company(123)
+
+      expect(address.street).to eq("Rua do Açaí, 25")
+      expect(address.zip).to eq("11111-111")
+      expect(address.city).to eq("São Paulo")
+      expect(address.state).to eq("SP")
+    end
+  end
+
   def restart_csv(file_path)
     CSV.open(file_path, "wb") do |csv|
       csv << %w[id company_id zip street city state]

--- a/spec/company_address_spec.rb
+++ b/spec/company_address_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe CompanyAddress do
+  csv_path = "spec/support/companies-addresses-test.csv"
+
+  before do
+    stub_const("CompanyAddress::DATA_PATH", csv_path)
+    restart_csv(csv_path)
+  end
+
+  after(:all) { restart_csv(csv_path) }
+
+  context ".create" do
+    it "creates a company address with id, company_id, zip, street, city, state" do
+      company_address = CompanyAddress.create(company_id: 123, zip: "11111-111", street: "Rua do Açaí, 25",
+                                              city: "São Paulo", state: "SP")
+
+      expect(company_address.company_id).to eq(123)
+      expect(company_address.street).to eq("Rua do Açaí, 25")
+      expect(company_address.zip).to eq("11111-111")
+      expect(company_address.city).to eq("São Paulo")
+      expect(company_address.state).to eq("SP")
+    end
+  end
+
+  def restart_csv(file_path)
+    CSV.open(file_path, "wb") do |csv|
+      csv << %w[id company_id zip street city state]
+    end
+  end
+end

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -76,6 +76,21 @@ RSpec.describe Company do
     end
   end
 
+  context "#address" do
+    it "returns the address from company" do
+      company = Company.create(name: "Casa do Açaí", phone: "11-11111111")
+      CompanyAddress.create(company_id: company.id.to_s, zip: "11111-111", street: "Rua do Açaí, 25", city: "São Paulo",
+                            state: "SP")
+
+      address = company.address
+
+      expect(address.street).to eq("Rua do Açaí, 25")
+      expect(address.zip).to eq("11111-111")
+      expect(address.city).to eq("São Paulo")
+      expect(address.state).to eq("SP")
+    end
+  end
+
   def restart_csv(file_path)
     CSV.open(file_path, "wb") do |csv|
       csv << %w[id name phone is_open]

--- a/spec/support/companies-addresses-test.csv
+++ b/spec/support/companies-addresses-test.csv
@@ -1,0 +1,1 @@
+id,company_id,zip,street,city,state


### PR DESCRIPTION
Adiciona endereço do estabelecimento com persistencia de dados, e também adiciona método #address para Company.

Classe: CompanyAddress
- id
- company_id
- zip
- street
- city
- state